### PR TITLE
Fix unicode characters in calendar data

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,12 @@
+function base64ToBlob(base64String) {
+  const binaryString = atob(base64String);
+  const codePoints = Array(binaryString.length);
+  for (let index = 0; index < binaryString.length; index++)
+    codePoints[index] = binaryString.codePointAt(index);
+  const uint8CodePoints = Uint8Array.from(codePoints);
+  return new Blob([uint8CodePoints]);
+}
+
 let downloading = null;
 let url = null;
 
@@ -22,8 +31,7 @@ browser.messageDisplayAction.onClicked.addListener(async (tab) => {
   }
   raw = raw[0].replace(/\n\n$/, "");
   raw = raw.replace(/^(.|\n)*\n\n/, "");
-  const ics = atob(raw);
-  const blob = new Blob([ics]);
+  const blob = base64ToBlob(raw);
   url = URL.createObjectURL(blob);
   downloading = await browser.downloads.download(
     {

--- a/background.js
+++ b/background.js
@@ -1,42 +1,41 @@
-var downloading = null;
-var url = null;
+let downloading = null;
+let url = null;
+
 browser.messageDisplayAction.onClicked.addListener(async (tab) => {
-  browser.messageDisplay.getDisplayedMessage(tab.id).then(async (message) => {
-    browser.messages.getRaw(message.id).then(async (raw) => {
-      raw = raw.replace(/\r/g, "");
-      raw = raw.match(/Content-Type: text\/calendar;(.|\n)*\n\n/);
-      if (raw === null) {
-        browser.notifications.create(
-          "no-appointment",
-          {
-            type: "basic",
-            message: "No appointment was found.",
-            title: "Outlook/Teams Appointments"
-          }
-        );
-        setTimeout(() => {
-          browser.notifications.clear("no-appointment");
-        }, 5000);
-        return;
+  const message = await browser.messageDisplay.getDisplayedMessage(tab.id)
+  let raw = await browser.messages.getRaw(message.id)
+  raw = raw.replace(/\r/g, "");
+  raw = raw.match(/Content-Type: text\/calendar;(.|\n)*\n\n/);
+  if (raw === null) {
+    browser.notifications.create(
+      "no-appointment",
+      {
+        type: "basic",
+        message: "No appointment was found.",
+        title: "Outlook/Teams Appointments"
       }
-      raw = raw[0].replace(/\n\n$/, "");
-      raw = raw.replace(/^(.|\n)*\n\n/, "");
-      var ics = atob(raw);
-      var blob = new Blob([ics]);
-      url = URL.createObjectURL(blob);
-      downloading = await browser.downloads.download(
-        {
-          "filename": "calendar.ics",
-          "saveAs": true,
-          "url": url
-        }
-      );
-    });
-  });
+    );
+    setTimeout(() => {
+      browser.notifications.clear("no-appointment");
+    }, 5000);
+    return;
+  }
+  raw = raw[0].replace(/\n\n$/, "");
+  raw = raw.replace(/^(.|\n)*\n\n/, "");
+  const ics = atob(raw);
+  const blob = new Blob([ics]);
+  url = URL.createObjectURL(blob);
+  downloading = await browser.downloads.download(
+    {
+      "filename": "calendar.ics",
+      "saveAs": true,
+      "url": url
+    }
+  );
 });
 
 browser.downloads.onChanged.addListener((downloadDelta) => {
-  if (downloadDelta.id == downloading && downloadDelta.state.current == "complete") {
+  if (downloadDelta.id === downloading && downloadDelta.state.current === "complete") {
     URL.revokeObjectURL(url);
   }
 });


### PR DESCRIPTION
Unicode characters in the calendar appointment data are broken in the downloaded ICS file.

JavaScript function `atob` transforms the Base64 string to a binary string, that is, each character represents a single byte of the Base64 data. This leads to non-ASCII characters like German umlauts not to be represented correctly in the ICS file.
