### PR TITLE
Fix colors.icons access errors

### DIFF
--- a/background.js
+++ b/background.js
@@ -21,7 +21,7 @@ async function getRawCalendar(message_id) {
 
 async function isDarkmode() {
   let theme = await browser.theme.getCurrent();
-  return theme.colors.icons == '#fbfbfe';
+  return theme.colors?.icons == '#fbfbfe';
 }
 
 async function updateIcon() {


### PR DESCRIPTION
When using some themes, the `theme` object returned from `browser.theme.getCurrent()` will not have a `colors` property defined. When we try to access `colors.icons`, TypeErrors are produced (every time a message with an appointment is opened):

![image](https://user-images.githubusercontent.com/1972633/152285071-74269a44-7eb4-479a-b0ad-ecbbebe9b791.png)
